### PR TITLE
Do not change state until get response from cloud

### DIFF
--- a/custom_components/eldes_alarm/alarm_control_panel.py
+++ b/custom_components/eldes_alarm/alarm_control_panel.py
@@ -87,8 +87,8 @@ class EldesAlarmPanel(EldesZoneEntity, AlarmControlPanelEntity):
                 self.entity_index
             )
 
-            self.data["state"] = STATE_ALARM_DISARMED
-            self.async_write_ha_state()
+ #           self.data["state"] = STATE_ALARM_DISARMED
+ #           self.async_write_ha_state()
         except Exception as ex:
             _LOGGER.error("Failed to change state: %s", ex)
             self.data["state"] = current_state
@@ -108,8 +108,8 @@ class EldesAlarmPanel(EldesZoneEntity, AlarmControlPanelEntity):
                 self.entity_index
             )
 
-            self.data["state"] = STATE_ALARM_ARMED_AWAY
-            self.async_write_ha_state()
+#            self.data["state"] = STATE_ALARM_ARMED_AWAY
+#            self.async_write_ha_state()
         except Exception as ex:
             _LOGGER.error("Failed to change state: %s", ex)
             self.data["state"] = current_state
@@ -129,8 +129,8 @@ class EldesAlarmPanel(EldesZoneEntity, AlarmControlPanelEntity):
                 self.entity_index
             )
 
-            self.data["state"] = STATE_ALARM_ARMED_HOME
-            self.async_write_ha_state()
+#            self.data["state"] = STATE_ALARM_ARMED_HOME
+#            self.async_write_ha_state()
         except Exception as ex:
             _LOGGER.error("Failed to change state: %s", ex)
             self.data["state"] = current_state


### PR DESCRIPTION
Still existing issue if get response while action not completed. For example arming state reseted to disarmed or disarming to armed_home or armed_away.