### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/eldes_alarm/__init__.py
+++ b/custom_components/eldes_alarm/__init__.py
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     # Setup components
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for eldes_alarm using this method at custom_components/eldes_alarm/__init__.py, line 91: hass.config_entries.async_setup_platforms(entry, PLATFORMS)