### PR TITLE
Fix for refresh tokens

### DIFF
--- a/custom_components/eldes_alarm/core/eldes_cloud.py
+++ b/custom_components/eldes_alarm/core/eldes_cloud.py
@@ -93,7 +93,7 @@ class EldesCloud:
         data = {
             "email": self._username,
             "password": self._password,
-            "hostDeviceId": ""
+            "hostDeviceId": "HomeAssistant"
         }
 
         url = f"{API_URL}{API_PATHS['AUTH']}login"


### PR DESCRIPTION
Refresh tokens include a `did` property (device identifier).
If this value is an empty string, the `/auth/token` endpoint returns a `401 Unauthorized error`:
```
{
  "error": "BadCredentialsException",
  "errorMassage": "Token id is invalid"
}
```
Providing any non-empty `hostDeviceId` during login ensures that the `did` field is set in the refresh token, allowing token refresh to succeed.

This should fix:
#48 and #51 